### PR TITLE
Fix REPORT parsing for multi-word outlier names

### DIFF
--- a/robert/report.py
+++ b/robert/report.py
@@ -437,7 +437,7 @@ class report:
                             if '-------' in lines[j]:
                                 break
                             elif 'SDs' in lines[j]:
-                                sd_line = float(lines[j].split()[2][1:])
+                                sd_line = float(lines[j].split()[-2][1:])
                                 if sd_line > max_SD:
                                     max_SD = sd_line
                         warnings_dict['max_sd_No PFI'] = max_SD
@@ -448,7 +448,7 @@ class report:
                             if '-------' in lines[j]:
                                 break
                             elif 'SDs' in lines[j]:
-                                sd_line = float(lines[j].split()[2][1:])
+                                sd_line = float(lines[j].split()[-2][1:])
                                 if sd_line > max_SD:
                                     max_SD = sd_line
                         warnings_dict['max_sd_PFI'] = max_SD


### PR DESCRIPTION
## Problem

The REPORT module fails when an outlier has a multi-word name, such as:

> `- Triethyl phosphate (2.1 SDs)`

The current parser assumes that the compound name contains only one word. It reads `phosphate` where it expects the standard-deviation value and raises:

> `ValueError: could not convert string to float: 'hosphate'`

## Fix

Changed:

`sd_line = float(lines[j].split()[2][1:])`

to:

`sd_line = float(lines[j].split()[-2][1:])`

The updated code reads the standard-deviation value relative to the end of the line, so it works regardless of how many words the compound name contains.

This change only fixes REPORT log parsing. It does not affect model predictions, outlier calculations, datasets, or generated results.